### PR TITLE
non-UCSC chromosome nomenclature & gzipped counts

### DIFF
--- a/R/contactsUMI4C.R
+++ b/R/contactsUMI4C.R
@@ -912,15 +912,19 @@ counterUMI4C <- function(wk_dir,
     file_name <- strsplit(basename(filtered_bam_R1), "_R1")[[1]][1]
     counts_file <- file.path(count_dir, paste0(file_name, "_counts.tsv"))
 
+    # gz file directly to avoid errors due to disk latency
+    gzf <- gzfile(paste0(counts_file, '.gz'), "w")
     utils::write.table(
-        x = final_umis,
-        file = counts_file,
-        row.names = FALSE,
-        quote = FALSE,
-        sep = "\t"
+    x = final_umis,
+    file = gzf,
+    row.names = FALSE,
+    quote = FALSE,
+    sep = "\t"
     )
+    close(gzf)
 
-    R.utils::gzip(counts_file, overwrite = TRUE)
+
+    # R.utils::gzip(counts_file, overwrite = TRUE)
 
     message(
         paste0("[", Sys.time(), "] "),

--- a/R/contactsUMI4C.R
+++ b/R/contactsUMI4C.R
@@ -740,12 +740,16 @@ counterUMI4C <- function(wk_dir,
     alignedR2_files <- aligned_files[grep("_R2", aligned_files)]
 
     # Load digested genome
-    file <- list.files(digested_genome,
-        pattern = paste0(as.character(GenomicRanges::seqnames(pos_viewpoint)), ".rda"),
-        full.names = TRUE
-    )
+    # Pattern matching breaks for ensembl based genomes (1.rda -> 11.rda)
+    # Assume that viewpoint can only correspond to 1 chromosome anyway, and fail if the 
+    file <- file.path(digested_genome, paste0(as.character(GenomicRanges::seqnames(pos_viewpoint)), ".rda"))
+    if (!file.exists(file)) stop(paste("No digested genome file found at: ", file))
 
-    if (length(file) == 0) stop(paste("No digested genome file"))
+    #file <- list.files(digested_genome,
+    #    pattern = paste0(as.character(GenomicRanges::seqnames(pos_viewpoint)), ".rda"),
+    #    full.names = TRUE
+    #)
+    #if (length(file) == 0) stop(paste("No digested genome file"))
 
     digested_genome_gr <- NULL # Avoid no visible binding for global variable
     load(file)


### PR DESCRIPTION
Hi,

First of all thanks for the software !
I've encountered two 'issues' when running this for my data:

 - when using an 'ensembl' based genome (forged BSgenome myself), the chromosomes are named 1,2,.... The pattern matching under list.files thus fails (i.e. 1.rda, 11.rda). I've changed this just a file.path, as I think it's fair to assume that (even in the UCSC case) there'll always be one (and only one) file matching.
 - the write.table - gzip chain for writing out the counts failed on our system (relatively slow disks), the workaround for this is to directly write out the counts file.

Cheers,

WardDeb